### PR TITLE
Update facebook IDs format from numbers to strings.

### DIFF
--- a/events.go
+++ b/events.go
@@ -6,16 +6,16 @@ type rawEvent struct {
 }
 
 type Event struct {
-	ID   int64 `json:"id"`
+	ID   int64 `json:"id,string"`
 	Time int64 `json:"time"`
 }
 
 type MessageOpts struct {
 	Sender struct {
-		ID int64 `json:"id"`
+		ID int64 `json:"id,string"`
 	} `json:"sender"`
 	Recipient struct {
-		ID int64 `json:"id"`
+		ID int64 `json:"id,string"`
 	} `json:"recipient"`
 	Timestamp int64 `json:"timestamp"`
 }

--- a/message.go
+++ b/message.go
@@ -16,7 +16,7 @@ type Message struct {
 // Recipient describes the person who will receive the message
 // Either ID or PhoneNumber has to be set
 type Recipient struct {
-	ID          int64  `json:"id,omitempty"`
+	ID          int64  `json:"id,string,omitempty"`
 	PhoneNumber string `json:"phone_number,omitempty"`
 }
 

--- a/messenger_test.go
+++ b/messenger_test.go
@@ -25,7 +25,7 @@ func setClient(code int, body []byte) *httptest.Server {
 }
 
 func TestCheckIntegrity(t *testing.T) {
-	if !checkIntegrity("e6af24be1d683c8c911949f897eea1f6", []byte(`{"object":"page","entry":[{"id":1751036168465324,"time":1460923697656,"messaging":[{"sender":{"id":982337261802700},"recipient":{"id":1751036168465324},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`), "f1a4569dcf02a9829a15696d949b386b7d6d0272") {
+	if !checkIntegrity("e6af24be1d683c8c911949f897eea1f6", []byte(`{"object":"page","entry":[{"id":"1751036168465324","time":1460923697656,"messaging":[{"sender":{"id":"982337261802700"},"recipient":{"id":"1751036168465324"},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`), "da611bd448dc12acdf0cd3ab33fdb3adaee26145") {
 		t.Error("Message integrity verification does not work")
 	}
 
@@ -64,11 +64,11 @@ func TestHandler(t *testing.T) {
 
 		mess.AppSecret = "e6af24be1d683c8c911949f897eea1f6"
 		// Legit Post request
-		postRequest, err := http.NewRequest("POST", "/", strings.NewReader(`{"object":"page","entry":[{"id":1751036168465324,"time":1460923697656,"messaging":[{"sender":{"id":982337261802700},"recipient":{"id":1751036168465324},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`))
+		postRequest, err := http.NewRequest("POST", "/", strings.NewReader(`{"object":"page","entry":[{"id":"1751036168465324","time":1460923697656,"messaging":[{"sender":{"id":"982337261802700"},"recipient":{"id":"1751036168465324"},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`))
 		if err != nil {
 			t.Error(err)
 		}
-		postRequest.Header.Add("x-hub-signature", "sha1=f1a4569dcf02a9829a15696d949b386b7d6d0272")
+		postRequest.Header.Add("x-hub-signature", "sha1=da611bd448dc12acdf0cd3ab33fdb3adaee26145")
 		response = r.Do(postRequest)
 		if response.StatusCode != http.StatusOK {
 			t.Errorf("Invalid status code, expected %d, got: %d", http.StatusOK, response.StatusCode)
@@ -78,14 +78,14 @@ func TestHandler(t *testing.T) {
 		mess.AppSecret = "abc"
 
 		// Invalid signature
-		response = r.Post("/", "application/json", `{"object":"page","entry":[{"id":1751036168465324,"time":1460923697656,"messaging":[{"sender":{"id":982337261802700},"recipient":{"id":1751036168465324},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`)
+		response = r.Post("/", "application/json", `{"object":"page","entry":[{"id":"1751036168465324","time":1460923697656,"messaging":[{"sender":{"id":"982337261802700"},"recipient":{"id":"1751036168465324"},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`)
 		if response.StatusCode != http.StatusBadRequest {
 			t.Errorf("Invalid status code, expected %d, got: %d", http.StatusBadRequest, response.StatusCode)
 		}
 
 		mess.AppSecret = ""
 		// Invalid request
-		response = r.Post("/", "application/json", `{"object":"page","entry":[{"id":1751036168465324,"time":1460923697656,"messaging":[{"sender":{"id":982337261802701751036168465324},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`)
+		response = r.Post("/", "application/json", `{"object":"page","entry":[{"id":"1751036168465324","time":1460923697656,"messaging":[{"sender":{"id":"982337261802701751036168465324"},"timestamp":1460923697635,"message":{"mid":"mid.1460923697625:5c96e8279b55505308","seq":614,"text":"Test \u00e4\u00eb\u00ef"}}]}]}`)
 		if response.StatusCode != http.StatusBadRequest {
 			t.Errorf("Invalid status code, expected %d, got: %d", http.StatusBadRequest, response.StatusCode)
 		}


### PR DESCRIPTION
Hi, thanks for the SDK!

According to https://developers.facebook.com/bugs/578746852290927/
> We decided to switch our encoding to use strings instead of ints for user & page IDs

The PR handles the matter and doesn't brake existing interface. But I think it would be better to change type from `int64` to `string` though.