### PR TITLE
Made attachments plural

### DIFF
--- a/events.go
+++ b/events.go
@@ -34,7 +34,7 @@ type MessageEvent struct {
 }
 
 type ReceivedMessage struct {
-	Message
+	ReceiveMessage
 	ID  string `json:"mid"`
 	Seq int    `json:"seq"`
 }

--- a/examples/template.go
+++ b/examples/template.go
@@ -9,7 +9,7 @@ import (
 
 func init() {
 	handler := func(event messenger.Event, opts messenger.MessageOpts, msg messenger.ReceivedMessage) {
-		resp, err := mess.SendMessage(messenger.MessageQuery{Recipient: messenger.Recipient{ID: opts.Sender.ID}, Message: messenger.Message{
+		resp, err := mess.SendMessage(messenger.MessageQuery{Recipient: messenger.Recipient{ID: opts.Sender.ID}, Message: messenger.SendMessage{
 			Attachment: &messenger.Attachment{
 				Type: messenger.AttachmentTypeTemplate,
 				Payload: &template.Payload{

--- a/message.go
+++ b/message.go
@@ -8,9 +8,13 @@ import (
 	"net/http"
 )
 
-type Message struct {
-	Text        string        `json:"text,omiempty"`
-	Attachment  *Attachment   `json:"attachment,omitempty"`
+type SendMessage struct {
+	Text       string      `json:"text,omiempty"`
+	Attachment *Attachment `json:"attachment,omitempty"`
+}
+
+type ReceiveMessage struct {
+	Text        string        `json:"text,omitempty"`
 	Attachments []*Attachment `json:"attachments,omitempty"`
 }
 
@@ -35,7 +39,7 @@ const (
 
 type MessageQuery struct {
 	Recipient        Recipient        `json:"recipient"`
-	Message          Message          `json:"message"`
+	Message          SendMessage      `json:"message"`
 	NotificationType NotificationType `json:"notification_type,omitempty"`
 }
 
@@ -75,7 +79,7 @@ func (m *Messenger) SendSimpleMessage(recipient string, message string) (*Messag
 		Recipient: Recipient{
 			ID: recipient,
 		},
-		Message: Message{
+		Message: SendMessage{
 			Text: message,
 		},
 	})

--- a/message.go
+++ b/message.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Message struct {
-	Text       string      `json:"text,omiempty"`
-	Attachment *Attachment `json:"attachment,omitempty"`
+	Text        string        `json:"text,omiempty"`
+	Attachment  *Attachment   `json:"attachment,omitempty"`
+	Attachments []*Attachment `json:"attachments,omitempty"`
 }
 
 // Recipient describes the person who will receive the message

--- a/welcomemessage.go
+++ b/welcomemessage.go
@@ -20,7 +20,7 @@ var welcomeMessage = ctaBase{
 
 type cta struct {
 	ctaBase
-	CallToActions []*Message `json:"call_to_actions"`
+	CallToActions []*SendMessage `json:"call_to_actions"`
 }
 
 type result struct {
@@ -28,10 +28,10 @@ type result struct {
 }
 
 // SetWelcomeMessage sets the message that is sent first. If message is nil or empty the welcome message is not sent.
-func (m *Messenger) SetWelcomeMessage(message *Message) error {
+func (m *Messenger) SetWelcomeMessage(message *SendMessage) error {
 	cta := &cta{
 		ctaBase:       welcomeMessage,
-		CallToActions: []*Message{message},
+		CallToActions: []*SendMessage{message},
 	}
 	if m.PageID == "" {
 		return errors.New("PageID is empty")

--- a/welcomemessage_test.go
+++ b/welcomemessage_test.go
@@ -23,7 +23,7 @@ func TestSetWelcomeMessage(t *testing.T) {
 
 	setClient(200, body)
 
-	err = messenger.SetWelcomeMessage(&Message{
+	err = messenger.SetWelcomeMessage(&SendMessage{
 		Text: "hello!",
 	})
 	if err != nil {
@@ -40,7 +40,7 @@ func TestSetWelcomeMessage(t *testing.T) {
 	}
 	setClient(200, body)
 
-	err = messenger.SetWelcomeMessage(&Message{})
+	err = messenger.SetWelcomeMessage(&SendMessage{})
 	if err == nil {
 		t.Error("Error should have been thrown!")
 	}


### PR DESCRIPTION
Feel free to delete this if I'm wrong, but the Facebook SDK suggests message attachments is `attachments` not `attachment`. 