### PR TITLE
QuickReply: set content type to be "text" and add test

### DIFF
--- a/messagequery.go
+++ b/messagequery.go
@@ -135,7 +135,11 @@ func (mq *MessageQuery) QuickReply(title string, payload string) error {
 	if len(payload) > 1000 {
 		return errors.New("Payload is too long, it has a 1000 character limit.")
 	}
-	mq.Message.QuickReplies = append(mq.Message.QuickReplies, QuickReply{Title: title, Payload: payload})
+	mq.Message.QuickReplies = append(mq.Message.QuickReplies, QuickReply{
+		ContentType: "text",
+		Title:       title,
+		Payload:     payload,
+	})
 	return nil
 }
 

--- a/messagequery_test.go
+++ b/messagequery_test.go
@@ -151,6 +151,11 @@ func TestQuickReply(t *testing.T) {
 	if err == nil {
 		t.Error("Can add an invalid quick reply")
 	}
+	for _, qr := range mq.Message.QuickReplies {
+		if qr.ContentType != "text" {
+			t.Error("QuickReply content type must be 'text'")
+		}
+	}
 }
 
 func TestMetadata(t *testing.T) {


### PR DESCRIPTION
quick_reply [specification](https://developers.facebook.com/docs/messenger-platform/send-api-reference/quick-replies#quick_reply) states that content_type's value must be "text"