### PR TITLE
Fix Facebook errors for account link and setting text

### DIFF
--- a/messagequery.go
+++ b/messagequery.go
@@ -66,9 +66,6 @@ func (mq *MessageQuery) Notification(notification NotificationType) *MessageQuer
 }
 
 func (mq *MessageQuery) Text(text string) error {
-	if mq.Message.Attachment == nil {
-		mq.Message.Attachment = &Attachment{}
-	}
 	if mq.Message.Attachment != nil && mq.Message.Attachment.Type == AttachmentTypeTemplate {
 		return errors.New("Can't set both text and template.")
 	}

--- a/template/buttons.go
+++ b/template/buttons.go
@@ -13,7 +13,7 @@ const (
 
 type Button struct {
 	Type    ButtonType `json:"type"`
-	Title   string     `json:"title"`
+	Title   string     `json:"title,omitempty"`
 	URL     string     `json:"url,omitempty"`
 	Payload string     `json:"payload,omitempty"`
 }


### PR DESCRIPTION
<b>Account Link</b>
Currently if you want to send an account link button, the title field will be sent as an empty string. The account link [doc](https://developers.facebook.com/docs/messenger-platform/account-linking/link-account) specifies that the button does not have a title field. Here is the MessageQuery being sent:
```
messenger.MessageQuery{
    Recipient: messenger.Recipient{ID:"myfacebookmessengerid", PhoneNumber:""},
    Message:   messenger.SendMessage{
        Text:       "",
        Attachment: &messenger.Attachment{
            Type:    "template",
            Payload: &template.Payload{
                Elements: {
                    &template.GenericTemplate{
                        Title:    "Link Facebook Account",
                        ItemURL:  "",
                        ImageURL: "",
                        Subtitle: "",
                        Buttons:  {
                            {Type:"account_link", Title:"", URL:"https://www.mywebsite.com/login", Payload:""},
                        },
                    },
                },
            },
        },
        QuickReplies: nil,
        Metadata:     "",
    },
    NotificationType: "",
}
```
Facebook will return an error:
```
(#100) Param [elements][0][buttons][0][title] must be a non-empty UTF-8 encoded string
```

Adding a non-empty title string will result in the error:
```
(#100) Title is not required for this account_link/account_unlink button.
```

<b>Setting MessageQuery's Text</b>
Attempting to send a MessageQuery after calling Text() will result in the following error:
```
(#100) The parameter message[attachment][type] is required
```
This is because there is no attachment on the message even though Attachment is not nil.