### PR TITLE
Fixed Event struct to parse a JSON string instead of a number.

### DIFF
--- a/events.go
+++ b/events.go
@@ -1,17 +1,19 @@
 package messenger
 
-import "encoding/json"
-
 type upstreamEvent struct {
 	Object  string          `json:"object"`
 	Entries []*MessageEvent `json:"entry"`
 }
 
+// Event represents a Webhook postback event.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference#format
 type Event struct {
-	ID   json.Number `json:"id"`
-	Time int64       `json:"time"`
+	ID   string `json:"id"`
+	Time int64  `json:"time"`
 }
 
+// MessageOpts contains information common to all message events.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference#format
 type MessageOpts struct {
 	Sender struct {
 		ID string `json:"id"`
@@ -22,6 +24,9 @@ type MessageOpts struct {
 	Timestamp int64 `json:"timestamp"`
 }
 
+// MessageEvent encapsulates common info plus the specific type of callback
+// being received.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference#format
 type MessageEvent struct {
 	Event
 	Messaging []struct {
@@ -34,6 +39,9 @@ type MessageEvent struct {
 	} `json:"messaging"`
 }
 
+// ReceivedMessage contains message specific information included with an echo
+// callback.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-echo
 type ReceivedMessage struct {
 	ID          string             `json:"mid"`
 	Text        string             `json:"text,omitempty"`
@@ -44,29 +52,41 @@ type ReceivedMessage struct {
 	Metadata    *string            `json:"metadata,omitempty"`
 }
 
+// QuickReplyPayload contains content specific to a quick reply.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message
 type QuickReplyPayload struct {
 	Payload string
 }
 
+// Delivery contains information specific to a message delivered callback.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-delivered
 type Delivery struct {
 	MessageIDS []string `json:"mids"`
 	Watermark  int64    `json:"watermark"`
 	Seq        int      `json:"seq"`
 }
 
+// Postback contains content specific to a postback.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message
 type Postback struct {
 	Payload string `json:"payload"`
 }
 
+// Optin contains information specific to Opt-In callbacks.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/optins
 type Optin struct {
 	Ref string `json:"ref"`
 }
 
+// Read contains data specific to message read callbacks.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-read
 type Read struct {
 	Watermark int64 `json:"watermark"`
 	Seq       int   `json:"seq"`
 }
 
+// MessageEcho contains information specific to an echo callback.
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/message-echo
 type MessageEcho struct {
 	ReceivedMessage
 	AppID int64 `json:"app_id,omitempty"`

--- a/events_test.go
+++ b/events_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEventUnmarshalJSON(t *testing.T) {
-	rawPostbackData := []byte(`{"id":1234,"time":1458692752478}`)
+	rawPostbackData := []byte(`{"id":"1234","time":1458692752478}`)
 	rawPageData := []byte(`{"id":"1234","time":1458692752478}`)
 	postbackEvent := &Event{}
 	err := json.Unmarshal(rawPostbackData, postbackEvent)


### PR DESCRIPTION
According to the docs, id is a string - not a number. Also added some comments.
https://developers.facebook.com/docs/messenger-platform/webhook-reference#format