### PR TITLE
Added list template

### DIFF
--- a/template/list.go
+++ b/template/list.go
@@ -1,0 +1,41 @@
+package template
+
+const TemplateTypeList TemplateType = "list"
+
+type ListTemplate struct {
+	Elements []ListElement `json:"elements"`
+	Buttons  []Button      `json:"buttons,omitempty"`
+}
+
+func (ListTemplate) Type() TemplateType {
+	return TemplateTypeList
+}
+
+func (ListTemplate) SupportsButtons() bool {
+	return true
+}
+
+type ListElement struct {
+	Title         string `json:"title"`
+	ImageURL      string `json:"image_url,omitempty"`
+	Subtitle      string `json:"subtitle,omitempty"`
+	DefaultAction `json:"default_action,omitempty"`
+	Buttons       []ListButton `json:"buttons,omitempty"`
+}
+
+type DefaultAction struct {
+	Type                string `json:"type"`
+	URL                 string `json:"url",omitempty`
+	MessengerExtensions bool   `json:"messenger_extensions",omitempty`
+	WebviewHeightRatio  string `json:"webview_height_ratio",omitempty`
+	FallbackURL         string `json:"fallback_url",omitempty`
+}
+
+type ListButton struct {
+	Title               string `json:"title"`
+	Type                string `json:"type",omitempty`
+	URL                 string `json:"url",omitempty`
+	MessengerExtensions bool   `json:"messenger_extensions",omitempty`
+	WebviewHeightRatio  string `json:"webview_height_ratio",omitempty`
+	FallbackURL         string `json:"fallback_url",omitempty`
+}

--- a/template/list_test.go
+++ b/template/list_test.go
@@ -1,0 +1,13 @@
+package template
+
+import "testing"
+
+func TestGenericType(t *testing.T) {
+	template := &ListTemplate{}
+	if template.Type() != TemplateTypeList {
+		t.Error("List template returned invalid type")
+	}
+	if !template.SupportsButtons() {
+		t.Error("List template supports buttons, but reports otherwise")
+	}
+}

--- a/template/list_test.go
+++ b/template/list_test.go
@@ -2,7 +2,7 @@ package template
 
 import "testing"
 
-func TestGenericType(t *testing.T) {
+func TestListType(t *testing.T) {
 	template := &ListTemplate{}
 	if template.Type() != TemplateTypeList {
 		t.Error("List template returned invalid type")


### PR DESCRIPTION
https://developers.facebook.com/docs/messenger-platform/send-api-reference/list-template

Note: 
- only 1 global button is supported
- max of 4 list elements
- the global button doesn't support URL (?). Not sure... but in the code I added, the list template uses the Button struct which does support URL