### PR TITLE
Messaging Tags Support

### DIFF
--- a/events.go
+++ b/events.go
@@ -90,14 +90,14 @@ type Referral struct {
 // The Pass Thread Control API of the handover protocol is used to pass control of a conversation from one app to another.
 // https://developers.facebook.com/docs/messenger-platform/handover-protocol/take-thread-control
 type PassThreadControl struct {
-	NewOwnerAppID	string`json:"new_owner_app_id,omitempty"`
+	NewOwnerAppID	int64 `json:"new_owner_app_id,omitempty"`
 	Metadata  		string`json:"metadata,omitempty"`
 }
 
 // Take Thread Control API allows the app with the Primary Receiver role to take control of the conversation 
 // https://developers.facebook.com/docs/messenger-platform/handover-protocol/pass-thread-control
 type TakeThreadControl struct {
-	PreviousOwnerAppID	string`json:"previous_owner_app_id,omitempty"`
+	PreviousOwnerAppID	int64 `json:"previous_owner_app_id,omitempty"`
 	Metadata  			string`json:"metadata,omitempty"`
 }
 

--- a/events.go
+++ b/events.go
@@ -34,12 +34,14 @@ type MessageEvent struct {
 	Event
 	Messaging []struct {
 		MessageOpts
-		Message  *MessageEcho `json:"message,omitempty"`
-		Delivery *Delivery    `json:"delivery,omitempty"`
-		Postback *Postback    `json:"postback,omitempty"`
-		Optin    *Optin       `json:"optin,omitempty"`
-		Read     *Read        `json:"read,omitempty"`
-		Referral *Referral    `json:"referral,omitempty"`
+		Message  		  *MessageEcho 			`json:"message,omitempty"`
+		Delivery 		  *Delivery  			`json:"delivery,omitempty"`
+		Postback 		  *Postback    			`json:"postback,omitempty"`
+		Optin    	      *Optin       			`json:"optin,omitempty"`
+		Read     		  *Read        		    `json:"read,omitempty"`
+		Referral 	      *Referral    			`json:"referral,omitempty"`
+		PassThreadControl *PassThreadControl 	`json:"pass_thread_control,omitempty"`
+		TakeThreadControl *TakeThreadControl 	`json:"take_thread_control,omitempty"`
 	} `json:"messaging"`
 }
 
@@ -78,11 +80,25 @@ type Postback struct {
 }
 
 // Referral contains content specific to a referal.
-// https://developers.facebook.com/docs/messenger-platform/webhook-reference/postback
+// https://developers.facebook.com/docs/messenger-platform/webhook-reference/referal
 type Referral struct {
 	Ref	string`json:"ref,omitempty"`
 	Source  string`json:"source,omitempty"`
 	Type    string`json:"type,omitempty"`
+}
+
+// The Pass Thread Control API of the handover protocol is used to pass control of a conversation from one app to another.
+// https://developers.facebook.com/docs/messenger-platform/handover-protocol/take-thread-control
+type PassThreadControl struct {
+	NewOwnerAppID	string`json:"new_owner_app_id,omitempty"`
+	Metadata  		string`json:"metadata,omitempty"`
+}
+
+// Take Thread Control API allows the app with the Primary Receiver role to take control of the conversation 
+// https://developers.facebook.com/docs/messenger-platform/handover-protocol/pass-thread-control
+type TakeThreadControl struct {
+	PreviousOwnerAppID	string`json:"previous_owner_app_id,omitempty"`
+	Metadata  			string`json:"metadata,omitempty"`
 }
 
 // Optin contains information specific to Opt-In callbacks.

--- a/message.go
+++ b/message.go
@@ -55,5 +55,6 @@ func (m *Messenger) SendSimpleMessage(recipient string, message string) (*Messag
 		Message: SendMessage{
 			Text: message,
 		},
+		MessagingType: MessagingTypeRegular,
 	})
 }

--- a/messagequery.go
+++ b/messagequery.go
@@ -46,10 +46,62 @@ const (
 	NotificationTypeNoPush NotificationType = "NO_PUSH"
 )
 
+// MessagingType identifies the messaging type of the message being sent
+type MessagingType string
+
+const (
+	// MessagingTypeRegular is in response to a received message
+	MessagingTypeRegular MessagingType = "RESPONSE"
+	// MessagingTypeUpdate is being sent proactively and is not in response to a received message
+	MessagingTypeUpdate MessagingType = "UPDATE"
+	// MessagingTypeTag is non-promotional and is being sent outside the 24-hour standard messaging window
+	MessagingTypeTag MessagingType = "MESSAGE_TAG"
+)
+
+// MessageTag identifies the messaging type of the message being sent
+type MessageTag string
+
+const (
+	// MessageTagCommunityAlert notifies the message recipient of emergency or utility alerts, or issue a safety check in your community.
+	MessageTagCommunityAlert MessageTag = "COMMUNITY_ALERT"
+	// MessageTagEventReminder sends the message recipient reminders of a scheduled event which a person is going to attend.
+	MessageTagEventReminder MessageTag = "CONFIRMED_EVENT_REMINDER"
+	// MessageTagNonPromotionalSubscription sends non-promotional messages under the News, Productivity, and Personal Trackers, ...
+	MessageTagNonPromotionalSubscription MessageTag = "NON_PROMOTIONAL_SUBSCRIPTION"
+	// MessageTagPairingUpdate notifies the message recipient that a pairing has been identified based on a prior request.
+	MessageTagPairingUpdate MessageTag = "PAIRING_UPDATE"
+	// MessageTagApplicationUpdate notifies the message recipient of an update on the status of their application.
+	MessageTagApplicationUpdate MessageTag = "APPLICATION_UPDATE"
+	// MessageTagAccountUpdate notifies the message recipient of a change to their account settings.
+	MessageTagAccountUpdate MessageTag = "ACCOUNT_UPDATE"
+	// MessageTagPaymentUpdate notifies the message recipient of a payment update for an existing transaction.
+	MessageTagPaymentUpdate MessageTag = "PAYMENT_UPDATE"
+	// MessageTagPersonalFinanceUpdate confirms a message recipient's financial activity.
+	MessageTagPersonalFinanceUpdate MessageTag = "PERSONAL_FINANCE_UPDATE"
+	// MessageTagShippingUpdate notifies the message recipient of a change in shipping status for a product that has already been purchased.
+	MessageTagShippingUpdate MessageTag = "SHIPPING_UPDATE"
+	// MessageTagReservationUpdate notifies the message recipient of updates to an existing reservation.
+	MessageTagReservationUpdate MessageTag = "RESERVATION_UPDATE"
+	// MessageTagIssueResolution notifies the message recipient of an update to a customer service issue that was initiated in a Messenger conversation.
+	MessageTagIssueResolution MessageTag = "ISSUE_RESOLUTION"
+	// MessageTagAppointmentUpdate notifies the message recipient of a change to an existing appointment.
+	MessageTagAppointmentUpdate MessageTag = "APPOINTMENT_UPDATE"
+	// MessageTagGameEvent notifies the message recipient of a change in in-game user progression, global events, or a live sporting event.
+	MessageTagGameEvent MessageTag = "GAME_EVENT"
+	// MessageTagTransportationUpdate notifies the message recipient of updates to an existing transportation reservation.
+	MessageTagTransportationUpdate MessageTag = "TRANSPORTATION_UPDATE"
+	// MessageTagFeatureFuntionalityUpdate notifies the message recipient of new features or functionality that become available in your bot.
+	MessageTagFeatureFuntionalityUpdate MessageTag = "FEATURE_FUNCTIONALITY_UPDATE"
+	// MessageTagFeatureTickerUpdate send the message recipient updates or reminders for an event for which a person already has a ticket.
+	MessageTagFeatureTickerUpdate MessageTag = "TICKET_UPDATE"
+)
+
 type MessageQuery struct {
 	Recipient        Recipient        `json:"recipient"`
 	Message          SendMessage      `json:"message"`
 	NotificationType NotificationType `json:"notification_type,omitempty"`
+	MessagingType 	 MessagingType 	  `json:"messaging_type,omitempty"`
+	MessageTag 	 	 MessageTag 	  `json:"tag,omitempty"`
 }
 
 func (mq *MessageQuery) RecipientID(recipientID string) error {

--- a/messagequery.go
+++ b/messagequery.go
@@ -125,6 +125,16 @@ func (mq *MessageQuery) Notification(notification NotificationType) *MessageQuer
 	return mq
 }
 
+func (mq *MessageQuery) Type(messagingType MessagingType) *MessageQuery {
+	mq.MessagingType = messagingType
+	return mq
+}
+
+func (mq *MessageQuery) Tag(tag MessageTag) *MessageQuery {
+	mq.MessageTag = tag
+	return mq
+}
+
 func (mq *MessageQuery) Text(text string) error {
 	if mq.Message.Attachment != nil && mq.Message.Attachment.Type == AttachmentTypeTemplate {
 		return errors.New("Can't set both text and template.")

--- a/profile.go
+++ b/profile.go
@@ -10,12 +10,12 @@ import (
 
 // Profile struct holds data associated with Facebook profile
 type Profile struct {
-	FirstName      string `json:"first_name"`
-	LastName       string `json:"last_name"`
-	ProfilePicture string `json:"profile_pic,omitempty"`
-	Locale         string `json:"locale,omitempty"`
-	Timezone       int    `json:"timezone,omitempty"`
-	Gender         string `json:"gender,omitempty"`
+	FirstName      string 	`json:"first_name"`
+	LastName       string 	`json:"last_name"`
+	ProfilePicture string 	`json:"profile_pic,omitempty"`
+	Locale         string 	`json:"locale,omitempty"`
+	Timezone       float64  `json:"timezone,omitempty"`
+	Gender         string 	`json:"gender,omitempty"`
 }
 
 // GetProfile fetches the recipient's profile from facebook platform


### PR DESCRIPTION
This version contains support for breaking changes occurring on the 7th May. (https://developers.facebook.com/docs/messenger-platform/send-messages)